### PR TITLE
Travis yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - |
     if [ $GHCVER = `ghc --numeric-version` ]; then
       # Try installing some of the build-deps with apt-get for speed.
-      travis/cabal-apt-install --enable-tests $MODE
+      travis/cabal-apt-install --enable-tests
       export CABAL=cabal
     else
       # Install the GHC we want from hvr's PPA
@@ -33,5 +33,13 @@ script:
   - $CABAL build
   - $CABAL check
   - $CABAL sdist
-  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ") 
+  # check that the generated source-distribution can be built & installed
+  - export SRC_TGZ=$($CABAL info . | awk '{print $2 ".tar.gz";exit}') ;
+    cd dist/;
+    if [ -f "$SRC_TGZ" ]; then
+       $CABAL install --force-reinstalls "$SRC_TGZ";
+    else
+       echo "expected '$SRC_TGZ' not found";
+       exit 1;
+    fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+# Travis script based on https://github.com/hvr/multi-ghc-travis
+
+env:
+  - GHCVER=7.8.4
+  - GHCVER=7.10.1
+
+before_install:
+  # If $GHCVER is the one travis has, don't bother reinstalling it.
+  # We can also have faster builds by installing some libraries with
+  # `apt`. If it isn't, install the GHC we want from hvr's PPA along
+  # with cabal-1.18.
+  - |
+    if [ $GHCVER = `ghc --numeric-version` ]; then
+      # Try installing some of the build-deps with apt-get for speed.
+      travis/cabal-apt-install --enable-tests $MODE
+      export CABAL=cabal
+    else
+      # Install the GHC we want from hvr's PPA
+      travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+      travis_retry sudo apt-get update
+      travis_retry sudo apt-get install cabal-install-1.18 ghc-$GHCVER happy
+      export CABAL=cabal-1.18
+      export PATH=/opt/ghc/$GHCVER/bin:$PATH
+    fi
+  # Download latest stackage nightly snapshot
+  - $CABAL update
+
+install:
+  - $CABAL install --dependencies-only
+  - $CABAL configure -flib-Werror
+
+script:
+  - $CABAL build
+  - $CABAL check
+  - $CABAL sdist
+  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ") 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,31 @@
 # Travis script based on https://github.com/hvr/multi-ghc-travis
 
 env:
-  - GHCVER=7.8.4
-  - GHCVER=7.10.1
+  - CABALVER=1.18 GHCVER=7.8.4
+  - CABALVER=1.22 GHCVER=7.10.1
 
 before_install:
-  # If $GHCVER is the one travis has, don't bother reinstalling it.
-  # We can also have faster builds by installing some libraries with
-  # `apt`. If it isn't, install the GHC we want from hvr's PPA along
-  # with cabal-1.18.
-  - |
-    if [ $GHCVER = `ghc --numeric-version` ]; then
-      # Try installing some of the build-deps with apt-get for speed.
-      travis/cabal-apt-install --enable-tests
-      export CABAL=cabal
-    else
-      # Install the GHC we want from hvr's PPA
-      travis_retry sudo add-apt-repository -y ppa:hvr/ghc
-      travis_retry sudo apt-get update
-      travis_retry sudo apt-get install cabal-install-1.18 ghc-$GHCVER happy
-      export CABAL=cabal-1.18
-      export PATH=/opt/ghc/$GHCVER/bin:$PATH
-    fi
-  # Download latest stackage nightly snapshot
-  - $CABAL update
+  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:
-  - $CABAL install --dependencies-only
-  - $CABAL configure -flib-Werror
+  - cabal --version
+  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+  - travis_retry cabal update
+  - cabal install --only-dependencies --enable-tests --enable-benchmarks
 
 script:
-  - $CABAL build
-  - $CABAL check
-  - $CABAL sdist
+  - cabal configure -flib-Werror -v2 --enable-tests --enable-benchmarks
+  - cabal build
+  - cabal check
+  - cabal sdist
   # check that the generated source-distribution can be built & installed
-  - export SRC_TGZ=$($CABAL info . | awk '{print $2 ".tar.gz";exit}') ;
+  - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
     cd dist/;
     if [ -f "$SRC_TGZ" ]; then
-       $CABAL install --force-reinstalls "$SRC_TGZ";
+       cabal install --force-reinstalls "$SRC_TGZ";
     else
        echo "expected '$SRC_TGZ' not found";
        exit 1;

--- a/stackage-cli.cabal
+++ b/stackage-cli.cabal
@@ -1,5 +1,5 @@
 name:                stackage-cli
-version:             0.0.0.1
+version:             0.0.0.2
 synopsis:
   A CLI library for stackage commands
 description:
@@ -13,6 +13,10 @@ build-type:          Simple
 cabal-version:       >=1.10
 category: Development
 extra-source-files:  README.md ChangeLog.md
+
+source-repository head
+  type:     git
+  location: git://github.com/fpco/stackage-cli.git
 
 library
   hs-source-dirs: src/


### PR DESCRIPTION
 Summary: New Travis-CI YAML file. It runs a compile at the moment on GHC versions 7.8.4 and 7.10. Tests and benchmarks are enabled in the configure but there is no call to cabal test or bench.

Version number on this PR is out of date, already!
