### PR TITLE
Use HTTPS instead of HTTP

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.0.0.4
+
+* stackage-init now uses https [#34](https://github.com/fpco/stackage-cli/pull/34)
+
 ## 0.0.0.3
 
 * Works with older versions of parsec [#28](https://github.com/fpco/stackage-cli/issues/28)

--- a/main/Init.hs
+++ b/main/Init.hs
@@ -16,6 +16,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.Typeable (Typeable)
 import Network.HTTP.Client
+import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.HTTP.Types.Status (statusCode)
 import Network.HTTP.Types.Header (hUserAgent)
 import qualified Data.ByteString.Lazy as LBS
@@ -52,7 +53,7 @@ snapshotParser = strArgument mods where
   mods = (metavar "SNAPSHOT" <> value "lts")
 
 toUrl :: Snapshot -> String
-toUrl t = "http://stackage.org/" <> t <> "/cabal.config"
+toUrl t = "https://www.stackage.org/" <> t <> "/cabal.config"
 
 snapshotReq :: Snapshot -> IO Request
 snapshotReq snapshot = case parseUrl (toUrl snapshot) of
@@ -62,7 +63,7 @@ snapshotReq snapshot = case parseUrl (toUrl snapshot) of
     }
 
 downloadSnapshot :: Snapshot -> IO LBS.ByteString
-downloadSnapshot snapshot = withManager defaultManagerSettings $ \manager -> do
+downloadSnapshot snapshot = withManager tlsManagerSettings $ \manager -> do
   let getResponseLbs req = do
         response <- httpLbs req manager
         return $ responseBody response

--- a/stackage-cli.cabal
+++ b/stackage-cli.cabal
@@ -1,5 +1,5 @@
 name:                stackage-cli
-version:             0.0.0.3
+version:             0.0.0.4
 synopsis:
   A CLI library for stackage commands
 description:

--- a/stackage-cli.cabal
+++ b/stackage-cli.cabal
@@ -77,6 +77,7 @@ executable stackage-init
     , system-fileio
     , optparse-applicative
     , http-client
+    , http-client-tls
     , http-types
     , bytestring
   default-language:    Haskell2010


### PR DESCRIPTION
Also note usage of www. Bare domains redirect to www, so it's better to
avoid the extra HTTP roundtrip.

Pinging @chrisdone 